### PR TITLE
fix: undelegate display with rewards

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -13,6 +13,7 @@ export const collector = (result: LogFinderActionResult[] | undefined) => {
           "delegate",
           "undelegate",
           "begin-redelegate",
+          "withdraw-delegation-reward"
         ]
 
         if (!types.includes(action)) {


### PR DESCRIPTION
Adding "withdraw-delegation-reward" to the collector types, allows the "unbond" message to come through with the "withdraw-delegation-reward" message.  Originally, only the "withdraw-delegation-reward" message would be returned due to it not being included in the types.

NOTE: "0stake" result for delegation reward being reworked on Alliance.

# Before
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/30275692/235872472-86208f29-226d-421d-aa86-b8c8dfaa8d2a.png">

# After
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/30275692/235872115-2b7f1cf5-6128-4ec0-ab2f-49d79677a7ea.png">
